### PR TITLE
Allow to use a URL for the 'safetyConfPath' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 
 ### Root level
 
-To override where the config file is read from, update the setting `safetyConfPath` in your `build.sbt`.
+To override where the config file is read from, update the setting `safetyConfPath` in your `build.sbt`. This setting can be a URL starting by `http://` or `https://` or a local file path. 
 By default it will search for `./safetyPlugin.json`.
 
 Root level:

--- a/publish.sbt
+++ b/publish.sbt
@@ -5,6 +5,4 @@ updateOptions := updateOptions.value.withGigahorse(false)
 
 publishArtifact in Test := false
 
-pomIncludeRepository := { _ =>
-  false
-}
+pomIncludeRepository := (_ => false)

--- a/src/main/scala/com/leobenkel/safetyplugin/Transformations/TaskConfiguration.scala
+++ b/src/main/scala/com/leobenkel/safetyplugin/Transformations/TaskConfiguration.scala
@@ -12,6 +12,7 @@ private[Transformations] trait TaskConfiguration {
 
       Def.setting {
         val conf = Config.ConfigurationParser(log, path)
+        log.info(s"Got configuration from '$path'")
         conf.getConf
       }
     }

--- a/src/sbt-test/SafetyPluginTest/config_web/build.sbt
+++ b/src/sbt-test/SafetyPluginTest/config_web/build.sbt
@@ -1,0 +1,9 @@
+lazy val root = (project in file("."))
+  .settings(
+    version                     := "0.1",
+    scalaVersion                := "2.11.12",
+    assemblyJarName in assembly := "foo.jar"
+  )
+
+safetyConfPath :=
+  "https://raw.githubusercontent.com/leobenkel/safety_plugin/master/safetyPlugin.json"

--- a/src/sbt-test/SafetyPluginTest/config_web/project/build.properties
+++ b/src/sbt-test/SafetyPluginTest/config_web/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.6

--- a/src/sbt-test/SafetyPluginTest/config_web/project/plugins.sbt
+++ b/src/sbt-test/SafetyPluginTest/config_web/project/plugins.sbt
@@ -1,0 +1,8 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.leobenkel" % "safety_plugin" % x)
+  case _ =>
+    sys.error(
+      "The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D"
+    )
+}

--- a/src/sbt-test/SafetyPluginTest/config_web/src/main/scala/hello.scala
+++ b/src/sbt-test/SafetyPluginTest/config_web/src/main/scala/hello.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/SafetyPluginTest/config_web/test
+++ b/src/sbt-test/SafetyPluginTest/config_web/test
@@ -1,0 +1,3 @@
+# check if the file gets created
+> assembly
+$ exists target/scala-2.11/foo.jar


### PR DESCRIPTION
# Allow to use a URL for the 'safetyConfPath' setting

## Describe your change:

Allow to use a URL for the 'safetyConfPath' setting

## Checklist - Check boxes in the PR UI, not by editing the text

### Pull Request

* [x] PR description is meaningful.
* [x] There are no more than a few commits to merge.
* [x] There are no more than a few lines of code to review.

### Code style

* [x] Maximum line length does not require scrolling in Github
* [x] FMT and ScalaStyle and ScalaFix are good

### Testing

* [x] Unit tests for the added/modified code 
* [x] Overall unit test coverage good
* [x] Unit tests are passing

### Dependencies

* [x] The plugin is added to itself
* [x] The latest version is added to itself
* [x] New dependencies do not have vulnerabilities

### Security

* [x] There is no known vulnerability being added to this project
* [x] Everything on this list is checked
